### PR TITLE
Using offset

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -209,8 +209,8 @@ Mohair = class
         @raw " LIMIT "
         @callOrBind count
 
-    skip: (count) ->
-        @raw " SKIP "
+    offset: (count) ->
+        @raw " OFFSET "
         @callOrBind count
 
     # Query

--- a/index.coffee
+++ b/index.coffee
@@ -207,11 +207,11 @@ Mohair = class
 
     limit: (count) ->
         @raw " LIMIT "
-        @callOrBind count
+        @callOrBind parseInt count
 
     offset: (count) ->
         @raw " OFFSET "
-        @callOrBind count
+        @callOrBind parseInt count
 
     # Query
     # =====


### PR DESCRIPTION
Using `offset` instead of  `skip`

Using `parseInt` in offset and limit to avoid parsing string params incorrectly
