### PR TITLE
parseInt in limit and offset to ensure not fail in mysql.query

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -58,9 +58,9 @@ Mohair = class
 
     order: (order) -> @set '_order', order
 
-    limit: (limit) -> @set '_limit', limit
+    limit: (limit) -> @set '_limit', parseInt limit
 
-    offset: (offset) -> @set '_offset', offset
+    offset: (offset) -> @set '_offset', parseInt offset
 
     # other
     # -----


### PR DESCRIPTION
Excellent  api syntax in the new version.

because of the node-mysql bug, we cant use string in limit and offset. 

``` coffee-script
mysql.query "select * from users limit ?", "1", handler
#  it will fail because the limit and offset only support integer type in node-mysql
```

so it is convenient for mohair to fix this problem by adding parseInt
