### PR TITLE
Select with params

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -36,7 +36,7 @@ module.exports =
 
     escape: (arg) -> @set '_escape', arg
 
-    select: (sql = '*') -> @set '_action', {verb: 'select', param: sql}
+    select: (sql = '*', args...) -> @set '_action', {verb: 'select', param: sql, args: args}
 
     delete: -> @set '_action', {verb: 'delete'}
 
@@ -102,6 +102,7 @@ module.exports =
             when 'insert'
                 @_action.param.forEach (x) -> params = params.concat values x
             when 'select'
+                params = params.concat @_action.args if @_action.args?
                 @_joins.forEach (join) ->
                     if join.criterion?
                         params = params.concat join.criterion.params()

--- a/test.coffee
+++ b/test.coffee
@@ -223,6 +223,17 @@ module.exports =
 
             test.done()
 
+        'select with param': (test) ->
+            subselect = "SELECT count(1) FROM has_many WHERE has_many.one_id = id AND state = ?"
+            select = "one.*, (#{subselect}) as partial_count"
+            q = mohair
+                .table('one')
+                .select(select, 'confirmed')
+            test.equal q.sql(), "SELECT #{select} FROM one"
+            test.deepEqual q.params(), ['confirmed']
+
+            test.done()
+
     'actions overwrite previous actions': (test) ->
         chain = mohair.table('user')
             .where(id: 3)


### PR DESCRIPTION
Hi @snd,

In this pull request you can find the select method with optional arguments.

The use case for arguments in select clauses is that you sometimes need to set the where clauses in subqueries, as explained in #22

If you like this pull request, it would be great if you can merge it.
If you have complains or change requests, please review the code and give me feedback.
