### PR TITLE
Allow null values in records 2+ when using insertMany

### DIFF
--- a/src/mohair.coffee
+++ b/src/mohair.coffee
@@ -42,7 +42,7 @@ module.exports =
             throw new Error msg if keys.length isnt keysOfFirstRecord.length
 
             keysOfFirstRecord.forEach (key) ->
-                throw new Error msg unless data[key]?
+                throw new Error msg unless data.hasOwnProperty key
 
         @fluent '_action', actions.insertMany array
 

--- a/test/mohair.coffee
+++ b/test/mohair.coffee
@@ -94,6 +94,20 @@ module.exports =
 
             test.done()
 
+        'records with null values': (test) ->
+            q = mohair.table('user').insertMany [
+                {name: 'foo', email: 'foo@example.com', age: null}
+                {email: 'bar@example.com', name: null, age: 25}
+                {age: 30, name: 'baz', email: null}
+            ]
+
+            test.equal q.sql(),
+                'INSERT INTO user(name, email, age) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?)'
+            test.deepEqual q.params(),
+                ['foo', 'foo@example.com', null, null, 'bar@example.com', 25, 'baz', null, 30]
+
+            test.done()
+
         'with raw without params': (test) ->
             q = mohair.table('user').insertMany [
                 {


### PR DESCRIPTION
I need to insert multiple records that have one or more null field values.  By testing data[key]?, any records with a null field value were throwing an error.
